### PR TITLE
ace: GRASS GIS parser support added

### DIFF
--- a/ace.html
+++ b/ace.html
@@ -6,13 +6,203 @@
 <p>
 The ace tool allows the execution of a single GRASS GIS command or
 a list of GRASS GIS commands on an actinia REST service
-(https://actinia.mundialis.de/). In addition it provides job management,
-the ability to list locations, mapsets and map layer the user has
-access to as well as the creation and deletion of mapsets.
+(<a href="https://actinia.mundialis.de/">https://actinia.mundialis.de/</a>).
+In addition it provides job management, the ability to list locations,
+mapsets and map layer the user has access to as well as the creation
+and deletion of mapsets.
 
 <p>
 The ace tool must be executed in an active GRASS GIS session and
 will use the current location of this session to access the actinia service.
+
+<h2>NOTES</h2>
+
+The <em>ace</em> tool allows the execution of single GRASS GIS command
+or a list of GRASS GIS commands on an actinia REST service. In addition
+it provides job management and the ability to list locations, mapsets
+and map layer the user has access to.
+
+<p>
+This tool must be executed in an active GRASS GIS session
+<!--
+and will use the current location to access the actinia service. The current location can
+be overwritten
+-->
+specified by the <b>location<b> option. All commands will be executed
+per default in an ephemeral database, hence generated output must be
+exported using augmented GRASS commands. The flag <b>-p</b> allows the
+execution of commands in the persistent user database. It should be used
+with <b>location</b> option.
+
+<p>
+The user must setup the following environmental variables to specify the
+actinia server and credentials (example):
+
+<div class="code"><pre>
+export ACTINIA_USER='demouser'
+export ACTINIA_PASSWORD='gu3st!pa55w0rd'
+export ACTINIA_URL='https://actinia.mundialis.de'
+</pre></div>
+
+<p>
+This tool takes a GRASS GIS command as argument (<em>grass_command</em>).
+In addition, there are options to:
+
+<ol>
+<li>execute a list of commands from an input script file.</li>
+<li>perform job management on the actinia server (list, info, kill)</li>
+<li>show the version of the actinia service</li>
+<li>show the locations and mapsets the user has access to</li>
+<li>show map layers of specific location/mapset</li>
+<li>create new persistent user specific locations</li>
+<li>create new persistent user specific mapsets</li>
+</ol>
+
+GRASS GIS commands can be augmented with actinia specific extensions. The
+<b>@</b> operator can be specified for an input parameter to import a web
+located resource and to specify the export of an output parameter.
+
+<h2>EXAMPLES</h2>
+
+<!--
+Single command example:
+
+<div class="code"><pre>
+ace grass_command="g.list raster"
+</pre></div>
+-->
+
+Single command example with location option:
+
+<div class="code"><pre>
+ace grass_command="g.list raster" location="nc_spm_08"
+</pre></div>
+
+The following commands from a script will import a raster layer from an
+internet source as raster map *elev*, sets the computational region to the
+map and computes the slope. Additional information about the raster layer
+are requested with <em>r.info</em> (save as text file <em>commands.sh</em>):
+
+<div class="code"><pre>
+# Import the web resource and set the region to the imported map
+g.region raster=elev@https://storage.googleapis.com/graas-geodata/elev_ned_30m.tif -ap
+# Compute univariate statistics
+r.univar map=elev
+r.info elev
+# Compute the slope of the imported map and export it as Cloud Optimized GeoTIFF
+r.slope.aspect elevation=elev slope=slope_elev+COG
+r.info slope_elev
+</pre></div>
+
+<!--
+<p>
+Run the script <em>commands.sh</em> in the current location on the actinia server:
+
+<div class="code"><pre>
+ace script="commands.sh"
+</pre></div>
+-->
+
+<p>
+Run the script <em>commands.sh</em> in the location "nc_spm_08" on the actinia
+server:
+
+<div class="code"><pre>
+ace location="nc_spm_08" script="commands.sh"
+</pre></div>
+
+<p>
+List all running jobs of the current user:
+
+<div class="code"><pre>
+ace list-jobs="running"
+</pre></div>
+
+<p>
+Get information about a specific job:
+
+<div class="code"><pre>
+ace info-job="resource_id-3ce07606-cc77-4188-942e-5a5fbc8f1091"
+</pre></div>
+
+<p>
+Kill a running job:
+
+<div class="code"><pre>
+ace kill-job="resource_id-3ce07606-cc77-4188-942e-5a5fbc8f1091"
+</pre></div>
+
+<p>
+List all locations the user has access to:
+
+<div class="code"><pre>
+ace -l
+
+<p>
+List all mapsets in the specified location the user access to:
+
+<div class="code"><pre>
+ace -m location="nc_spm_08"
+</pre></div>
+
+<p>
+List all raster maps in mapset "PERMANENT" of the location "nc_spm_08":
+
+<div class="code"><pre>
+ace location="nc_spm_08" mapset="PERMANENT" -r
+</pre></div>
+
+<p>
+List all vector maps in mapsets PERMANENT of the location "nc_spm_08":
+
+<div class="code"><pre>
+ace location="nc_spm_08" mapset="PERMANENT" -v
+</pre></div>
+
+<p>
+List all strds in mapsets PERMANENT of the location "nc_spm_08":
+
+<div class="code"><pre>
+ace location="nc_spm_08" mapset="PERMANENT" -s
+</pre></div>
+
+<p>
+Create a new location "test_location" in the persistent user database:
+
+<div class="code"><pre>
+ace create-location="test_location 4326"
+</pre></div>
+
+<p>
+Delete "test_location" from the persistent user database:
+
+<div class="code"><pre>
+ace delete-location="test_location"
+</pre></div>
+
+<p>
+Create a new mapset in location "nc_spm_08" in the persistent user database:
+
+<div class="code"><pre>
+ace location="nc_spm_08" create-mapset="test_mapset"
+</pre></div>
+
+<p>
+Delete test_mapset mapset from location "nc_spm_08" in the persistent user
+database:
+
+<div class="code"><pre>
+ace location="nc_spm_08" delete-mapset="test_mapset"
+</pre></div>
+
+<p>
+Run command <em>g.list</em> in the persistent user database in location "nc_spm_08"
+mapset test_mapset:
+
+<div class="code"><pre>
+ace location="nc_spm_08 -p mapset="test_mapset" grass_commmand="g.list type=raster mapset=test_mapset"
+</pre></div>
+
 
 <h2>AUTHOR</h2>
 
@@ -20,5 +210,7 @@ Soeren Gebbert
 
 Original source: https://github.com/mundialis/actinia_core/blob/master/scripts/ace
 
+<p>
+GRASS GIS parser support: Markus Neteler, <a href="https://www.mundialis.de">mundialis</a>
 <p>
 <i>Last changed: $Date$</i>

--- a/ace.html
+++ b/ace.html
@@ -185,7 +185,7 @@ ace delete-location="test_location"
 Create a new mapset in location "nc_spm_08" in the persistent user database:
 
 <div class="code"><pre>
-ace location="nc_spm_08" create-mapset="test_mapset"
+ace location="nc_spm_08" create_mapset="test_mapset"
 </pre></div>
 
 <p>
@@ -193,7 +193,7 @@ Delete test_mapset mapset from location "nc_spm_08" in the persistent user
 database:
 
 <div class="code"><pre>
-ace location="nc_spm_08" delete-mapset="test_mapset"
+ace location="nc_spm_08" delete_mapset="test_mapset"
 </pre></div>
 
 <p>

--- a/ace.html
+++ b/ace.html
@@ -28,7 +28,7 @@ This tool must be executed in an active GRASS GIS session
 and will use the current location to access the actinia service. The current location can
 be overwritten
 -->
-specified by the <b>location<b> option. All commands will be executed
+specified by the <b>location</b> option. All commands will be executed
 per default in an ephemeral database, hence generated output must be
 exported using augmented GRASS commands. The flag <b>-p</b> allows the
 execution of commands in the persistent user database. It should be used
@@ -137,6 +137,7 @@ List all locations the user has access to:
 
 <div class="code"><pre>
 ace -l
+</pre></div>
 
 <p>
 List all mapsets in the specified location the user access to:
@@ -212,5 +213,7 @@ Original source: https://github.com/mundialis/actinia_core/blob/master/scripts/a
 
 <p>
 GRASS GIS parser support: Markus Neteler, <a href="https://www.mundialis.de">mundialis</a>
+<!--
 <p>
 <i>Last changed: $Date$</i>
+-->

--- a/ace.html
+++ b/ace.html
@@ -201,7 +201,7 @@ Run command <em>g.list</em> in the persistent user database in location "nc_spm_
 mapset test_mapset:
 
 <div class="code"><pre>
-ace location="nc_spm_08 -p mapset="test_mapset" grass_commmand="g.list type=raster mapset=test_mapset"
+ace location="nc_spm_08" -p mapset="test_mapset" grass_command="g.list type=raster mapset=test_mapset"
 </pre></div>
 
 

--- a/ace.py
+++ b/ace.py
@@ -209,9 +209,9 @@ r.info neighbour_elev
 #% requires: create_mapset, location
 #% requires: delete_mapset, location
 #% requires: -m, location
-#% requires: -r, location
-#% requires: -v, location
-#% requires: -s, location
+#% requires_all: -r, location, mapset
+#% requires_all: -v, location, mapset
+#% requires_all: -s, location, mapset
 #%end
 
 # Default values
@@ -367,7 +367,6 @@ def list_maps_of_mapsets(mapset: str, map_type: str):
         map_type: The map type: raster_layers, vector_layers, strds
 
     """
-
     # Read location and mapset
     # mapset = grass.read_command("g.mapset", "p").strip()
 
@@ -641,7 +640,7 @@ def main():
     list_raster = flags["r"]
     list_vector = flags["v"]
     list_strds = flags["s"]
-    persistent = False
+    mapset = False
 
     grass_command = options["grass_command"]
     script = options["script"]
@@ -650,7 +649,7 @@ def main():
     info_job = options["info_job"]
     location = options["location"]
     if options["mapset"]:
-        persistent = options["mapset"]
+        mapset = options["mapset"]
     create_mapset = options["create_mapset"]
     delete_mapset = options["delete_mapset"]
     create_location = options["create_location"]
@@ -685,15 +684,15 @@ def main():
     if location:
         setup_location(location=location)
         if script:
-            execute_script(script=script, mapset=persistent)
+            execute_script(script=script, mapset=mapset)
         elif list_mapsets:
             list_user_mapsets(location)
-        elif list_raster:
-            list_maps_of_mapsets(mapset=list_raster, map_type="raster_layers")
-        elif list_vector:
-            list_maps_of_mapsets(mapset=list_vector, map_type="vector_layers")
-        elif list_strds:
-            list_maps_of_mapsets(mapset=list_strds, map_type="strds")
+        elif list_raster and mapset is not False:
+            list_maps_of_mapsets(mapset=mapset, map_type="raster_layers")
+        elif list_vector and mapset is not False:
+            list_maps_of_mapsets(mapset=mapset, map_type="vector_layers")
+        elif list_strds and mapset is not False:
+            list_maps_of_mapsets(mapset=mapset, map_type="strds")
         elif render_raster:
             show_rendered_map(map_name=render_raster, map_type="raster_layers")
         elif render_vector:
@@ -707,7 +706,7 @@ def main():
         else:
             # TODO: fails with r3 (r.g. r3.info
             if is_grass_command(grass_command):
-                send_poll_commands(commands=[split_grass_command(grass_command), ], mapset=persistent)
+                send_poll_commands(commands=[split_grass_command(grass_command), ], mapset=mapset)
     elif list_jobs:
         if not list_jobs:
             list_jobs = "all"
@@ -737,12 +736,12 @@ def main():
     elif delete_mapset:
         delete_persistent_mapset(mapset=delete_mapset)
     elif script:
-        execute_script(script=script, mapset=persistent)
+        execute_script(script=script, mapset=mapset)
     else:
         if len(sys.argv) > 1:
             # TODO: fails with r3 (r.g. r3.info
             if is_grass_command(grass_command):
-                send_poll_commands(commands=[list(grass_command), ], mapset=persistent)
+                send_poll_commands(commands=[list(grass_command), ], mapset=mapset)
         else:
             actinia_version()
 

--- a/ace.py
+++ b/ace.py
@@ -105,11 +105,6 @@ r.info neighbour_elev
 #%end
 
 #%flag
-#% key: p
-#% description: Use a persistent database location/mapset for processing on the actinia server
-#%end
-
-#%flag
 #% key: r
 #% description: List raster maps of mapsets of specified location
 #%end
@@ -162,7 +157,7 @@ r.info neighbour_elev
 #%option
 #% key: mapset
 #% description: TODO
-#% label: Use this mapset name for processing on the actinia server
+#% label: Use this persistent mapset name for processing on the actinia server
 #%end
 
 #%option
@@ -609,7 +604,7 @@ def main():
     list_raster = flags["r"]
     list_vector = flags["v"]
     list_strds = flags["s"]
-    persistent = flags["p"]
+    persistent = False
 
     grass_command = options["grass_command"]
     script = options["script"]
@@ -617,7 +612,8 @@ def main():
     list_jobs = options["list_jobs"]
     info_job = options["info_job"]
     location = options["location"]
-    # ?? mapset = options["mapset"]
+    if options["mapset"]:
+        persistent = options["mapset"]
     create_mapset = options["create_mapset"]
     delete_mapset = options["delete_mapset"]
     create_location = options["create_location"]

--- a/ace.py
+++ b/ace.py
@@ -77,146 +77,146 @@ r.neighbors input=elevation output=neighbour_elev+GTiff
 r.info neighbour_elev
 """
 
-# %Module
-# % description: Allows the execution of single GRASS GIS command or a list of GRASS GIS commands on an actinia REST service.
-# % keyword: general
-# % keyword: API
-# % keyword: REST
-# %End
+#%Module
+#% description: Allows the execution of single GRASS GIS command or a list of GRASS GIS commands on an actinia REST service.
+#% keyword: general
+#% keyword: API
+#% keyword: REST
+#%End
 
-# %flag
-# % key: a
-# % description: Request the version of the actinia server
-# %end
+#%flag
+#% key: a
+#% description: Request the version of the actinia server
+#%end
 
-# %flag
-# % key: d
-# % description: Dry run: just print the JSON request and do not send the generated request to the server
-# %end
+#%flag
+#% key: d
+#% description: Dry run: just print the JSON request and do not send the generated request to the server
+#%end
 
-# %flag
-# % key: l
-# % description: List locations the user has access to
-# %end
+#%flag
+#% key: l
+#% description: List locations the user has access to
+#%end
 
-# %flag
-# % key: m
-# % description: List mapsets within specified location
-# %end
+#%flag
+#% key: m
+#% description: List mapsets within specified location
+#%end
 
-# %flag
-# % key: p
-# % description: Use a persistent database location/mapset for processing on the actinia server
-# %end
+#%flag
+#% key: p
+#% description: Use a persistent database location/mapset for processing on the actinia server
+#%end
 
-# %flag
-# % key: r
-# % description: List raster maps of mapsets of specified location
-# %end
+#%flag
+#% key: r
+#% description: List raster maps of mapsets of specified location
+#%end
 
-# %flag
-# % key: v
-# % description: List vector maps of mapsets of specified location
-# %end
+#%flag
+#% key: v
+#% description: List vector maps of mapsets of specified location
+#%end
 
-# %flag
-# % key: s
-# % description: List STRDS of mapsets of specified location
-# %end
+#%flag
+#% key: s
+#% description: List STRDS of mapsets of specified location
+#%end
 
-# %option
-# % key: grass_command
-# % type: string
-# % description: GRASS GIS command to be executed
-# %end
+#%option
+#% key: grass_command
+#% type: string
+#% description: GRASS GIS command to be executed
+#%end
 
-# %option
-# % key: script
-# % type: string
-# % description: Script to be executed
-# % label: Script file from which all all commands will be executed on the actinia server
-# %end
+#%option
+#% key: script
+#% type: string
+#% description: Script to be executed
+#% label: Script file from which all all commands will be executed on the actinia server
+#%end
 
-# %option
-# % key: list_jobs
-# % options: all,accepted,running,terminated,finished,error
-# % description: List all jobs of the user
-# %end
+#%option
+#% key: list_jobs
+#% options: all,accepted,running,terminated,finished,error
+#% description: List all jobs of the user
+#%end
 
-# %option
-# % key: info_job
-# % description: Show information about a job (use job-ID)
-# %end
+#%option
+#% key: info_job
+#% description: Show information about a job (use job-ID)
+#%end
 
-# %option
-# % key: kill_job
-# % description: Kill a job (use job-ID)
-# %end
+#%option
+#% key: kill_job
+#% description: Kill a job (use job-ID)
+#%end
 
-# %option
-# % key: location
-# % description: TODO
-# % label: Use this location name for processing on the actinia server
-# %end
+#%option
+#% key: location
+#% description: TODO
+#% label: Use this location name for processing on the actinia server
+#%end
 
-# %option
-# % key: mapset
-# % description: TODO
-# % label: Use this mapset name for processing on the actinia server
-# %end
+#%option
+#% key: mapset
+#% description: TODO
+#% label: Use this mapset name for processing on the actinia server
+#%end
 
-# %option
-# % key: create_location
-# % description: TODO
-# % label: Create new location in the persistent database of the actinia server using the provided EPSG code, e.g.: create_location="latlon 4326"
-# %end
+#%option
+#% key: create_location
+#% description: TODO
+#% label: Create new location in the persistent database of the actinia server using the provided EPSG code, e.g.: create_location="latlon 4326"
+#%end
 
-# %option
-# % key: delete_location
-# % description: TODO
-# % label: Delete existing location from the actinia server
-# %end
+#%option
+#% key: delete_location
+#% description: TODO
+#% label: Delete existing location from the actinia server
+#%end
 
-# %option
-# % key: create_mapset
-# % description: TODO
-# % label: Create a new mapset in the persistent database of the actinia server using the specified location
-# %end
+#%option
+#% key: create_mapset
+#% description: TODO
+#% label: Create a new mapset in the persistent database of the actinia server using the specified location
+#%end
 
-# %option
-# % key: delete_mapset
-# % description: TODO
-# % label: Delete an existing mapset from the actinia server using the specified location
-# %end
+#%option
+#% key: delete_mapset
+#% description: TODO
+#% label: Delete an existing mapset from the actinia server using the specified location
+#%end
 
-# %option
-# % key: render_raster
-# % description: TODO
-# % label: Show a rendered image from a specific raster map
-# %end
+#%option
+#% key: render_raster
+#% description: TODO
+#% label: Show a rendered image from a specific raster map
+#%end
 
-# %option
-# % key: render_vector
-# % description: TODO
-# % label: Show a rendered image from a specific vector map
-# %end
+#%option
+#% key: render_vector
+#% description: TODO
+#% label: Show a rendered image from a specific vector map
+#%end
 
-# %option
-# % key: render_strds
-# % description: TODO
-# % label: Show a rendered image from a specific STRDS
-# %end
+#%option
+#% key: render_strds
+#% description: TODO
+#% label: Show a rendered image from a specific STRDS
+#%end
 
 ### ?? #% requires: grass_command, location
 
-# % rules
-# % requires: create_mapset, location
-# % requires: delete_mapset, location
-# % requires: -m, location
-# % requires: -r, location
-# % requires: -v, location
-# % requires: -s, location
-# %end
+#% rules
+#% requires: create_mapset, location
+#% requires: delete_mapset, location
+#% requires: -m, location
+#% requires: -r, location
+#% requires: -v, location
+#% requires: -s, location
+#%end
 
 # Default values
 ACTINIA_USER = 'demouser'

--- a/ace.py
+++ b/ace.py
@@ -345,11 +345,11 @@ def list_user_locations():
         pprint(data)
 
 
-def list_user_mapsets():
+def list_user_mapsets(location):
     """List all mapsets of a specific location
     """
 
-    url = ACTINIA_URL + "/api/v1/locations/{LOCATION}/mapsets"
+    url = f"{ACTINIA_URL}/api/v1/locations/{location}/mapsets"
     r = requests.get(url, auth=ACTINIA_AUTH)
 
     data = simplejson.loads(r.text)
@@ -687,7 +687,7 @@ def main():
         if script:
             execute_script(script=script, mapset=persistent)
         elif list_mapsets:
-            list_user_mapsets()
+            list_user_mapsets(location)
         elif list_raster:
             list_maps_of_mapsets(mapset=list_raster, map_type="raster_layers")
         elif list_vector:
@@ -731,7 +731,7 @@ def main():
     elif render_strds:
         show_rendered_map(map_name=render_strds, map_type="strds")
     elif list_mapsets:
-        list_user_mapsets()
+        list_user_mapsets(location)
     elif create_mapset:
         create_persistent_mapset(mapset=create_mapset)
     elif delete_mapset:


### PR DESCRIPTION
Needed to make script installable with

```
g.extension ace url=https://github.com/mundialis/ace
```

## Old style

```
ace --help
Usage: ace [OPTIONS] [GRASS_COMMAND]...

  This tool allows the execution of single GRASS GIS command or a list of
  GRASS GIS commands on an actinia REST service. In addition it provides job
  management and the ability to list locations, mapsets and map layer the
  user has access to.

  This tool must be executed in an active GRASS GIS session and will use the
  current location to access the actinia service. The current location can
  be overwritten by the *--location* option. All commands will be executed
  per default in an ephemeral database, hence generated output must be
  exported using augmented GRASS commands. The option --persistent
  MAPSET_NAME allows the execution of commands in the persistent user
  database. It should be used with --location option.

  The user must setup the following environmental variables to specify the
  actinia server and credentials:

      export ACTINIA_USER='user'
      export ACTINIA_PASSWORD='password'
      export ACTINIA_URL='https://actinia.mundialis.de/latest'

  This tool takes a GRASS GIS command as argument. In addition there are
  options to:

      1. Execute a list of commands from an input script file.
      2. Perform job management on the actinia server (list, info, kill)
      3. Show the version of the actinia service
      4. Show the locations and mapsets the user has access to
      5. Show map layers of specific location/mapset
      6. Create new persistent user specific locations
      7. Create new persistent user specific mapsets

  GRASS GIS commands can be augmented with actinia specific extensions. The
  + operator can be specified for an input parameter to import a web located
  resource and to specify the export of an output parameter.

  Single command example:

      ace g.list raster

  Single command example with location option:

      ace --location nc_spm_08 g.list raster

  The following commands from a script will import a raster layer from an
  internet source as raster map *elev*, sets the computational region to the
  map and computes the slope. Additional information about the raster layer
  are requested with r.info:

      # Import the web resource and set the region to the imported map
      g.region raster=elev@https://storage.googleapis.com/graas-geodata/elev_ned_30m.tif -ap
      # Compute univariate statistics
      r.univar map=elev
      r.info elev
      # Compute the slope of the imported map and mark it for export
      r.slope.aspect elevation=elev slope=slope_elev+GTiff
      r.info slope_elev

  Run the script commands.sh in the current location on the actinia server:

      ace --script commands.sh

  Run the script commands.sh in the location *latlong_wgs84* on the actinia
  server:

      ace --location latlong_wgs84 --script commands.sh

  List all running jobs of the current user

      ace --list-jobs running

  Get information about a specific job

      ace --info-job resource_id-3ce07606-cc77-4188-942e-5a5fbc8f1091

  Kill a running job

      ace --kill-job resource_id-3ce07606-cc77-4188-942e-5a5fbc8f1091

  List all locations the user has access to:

      ace --list-locations

  List all mapsets of the current location the user access to:

      ace --list-mapsets

  List all mapsets of the location *nc_spm_08* the user access to:

      ace --list-mapsets --location nc_spm_08

  List all raster maps in mapsets PERMANENT of the location *nc_spm_08*:

      ace --location nc_spm_08 --list-raster PERMANENT

  List all vector maps in mapsets PERMANENT of the location *nc_spm_08*:

      ace --location nc_spm_08 --list-vector PERMANENT

  List all strds in mapsets PERMANENT of the location *nc_spm_08*:

      ace --location nc_spm_08 --list-strds PERMANENT

  Create a new location test_location in the persistent user database

      ace --create-location test_location 4326

  Delete test_location from the persistent user database

      ace --delete-location test_location

  Create a new mapset in location nc_spm_08 in the persistent user database

      ace --location nc_spm_08 --create-mapset test_mapset

  Delete test_mapset mapset from location nc_spm_08 in the persistent user
  database

      ace --location nc_spm_08 --delete-mapset test_mapset

  Run command g.list in the persistent user database in location nc_spm_08
  mapset test_mapset

      ace --location nc_spm_08 --persistent test_mapset g.list type=raster
      mapset=test_mapset

Options:
  --version                       Request the version of the server.
  --script TEXT                   The script file from which all all commands
                                  will be executed on the actinia server.

  --list-jobs [all|accepted|running|terminated|finished|error]
                                  List all jobs of the user.
  --info-job TEXT                 Show information about a job.
  --kill-job TEXT                 Kill a job.
  --list-locations                List locations the user has access to.
  --list-mapsets                  List mapsets of the current or a provided
                                  location

  --list-raster TEXT              List raster maps of mapsets from the current
                                  or a provided location

  --list-vector TEXT              List vector maps of mapsets from the current
                                  or a provided location

  --list-strds TEXT               List strds of mapsets from the current or a
                                  provided location

  --render-raster TEXT            Show a rendered image from a specific raster
                                  map

  --render-vector TEXT            Show a rendered image from a specific vector
                                  map

  --render-strds TEXT             Show a rendered image from a specific strds
  --create-mapset TEXT            Create a new mapset in the persistent
                                  database of the actinia server using the
                                  current or the provided location

  --delete-mapset TEXT            Delete an existing mapset from the actinia
                                  server using the current or the provided
                                  location

  --create-location TEXT...       Create a new location in the persistent
                                  database of the actinia server using the
                                  provided EPSG code, e.g.: --create-location
                                  latlon 4326

  --delete-location TEXT          Delete an existing location from the actinia
                                  server

  --persistent TEXT               Use a persistent database location/mapset
                                  for processing on the actinia server

  --dry-run                       Just print the JSON request and do not send
                                  the generated request to the server.

  --location TEXT                 Use this location for processing instead of
                                  the current one on the actinia server

  --help                          Show this message and exit.
```

## New style (GRASS GIS parser enabled)

```
ace --help
Allows the execution of single GRASS GIS command or a list of GRASS GIS commands on an actinia REST service.

Usage:
 ace [-adlmprvs] [grass_command=string] [script=string]
   [list_jobs=value] [info_job=value] [kill_job=value] [location=value]
   [mapset=value] [create_location=value] [delete_location=value]
   [create_mapset=value] [delete_mapset=value] [render_raster=value]
   [render_vector=value] [render_strds=value] [--help] [--verbose]
   [--quiet] [--ui]

Flags:
  -a   Request the version of the actinia server
  -d   Dry run: just print the JSON request and do not send the generated request to the server
  -l   List locations the user has access to
  -m   List mapsets within specified location
  -p   Use a persistent database location/mapset for processing on the actinia server
  -r   List raster maps of mapsets of specified location
  -v   List vector maps of mapsets of specified location
  -s   List STRDS of mapsets of specified location

Parameters:
    grass_command   GRASS GIS command to be executed
           script   Script file from which all all commands will be executed on the actinia server
        list_jobs   List all jobs of the user
                    options: all,accepted,running,terminated,finished,error
         info_job   Show information about a job (use job-ID)
         kill_job   Kill a job (use job-ID)
         location   Use this location name for processing on the actinia server
           mapset   Use this mapset name for processing on the actinia server
  create_location   Create new location in the persistent database of the actinia server using the provided EPSG code, e.g.: create_location="latlon 4326"
  delete_location   Delete existing location from the actinia server
    create_mapset   Create a new mapset in the persistent database of the actinia server using the specified location
    delete_mapset   Delete an existing mapset from the actinia server using the specified location
    render_raster   Show a rendered image from a specific raster map
    render_vector   Show a rendered image from a specific vector map
     render_strds   Show a rendered image from a specific STRDS
```

along with the new manual page:

```
g.manual ace
```

![image](https://user-images.githubusercontent.com/1295172/110258501-2c073a00-7fa3-11eb-9577-50a748b182f1.png)

(see also https://github.com/mundialis/actinia_core/issues/151)